### PR TITLE
X-Forwarded-For should only contain the IP address

### DIFF
--- a/src/web/proxyhttp.rs
+++ b/src/web/proxyhttp.rs
@@ -229,11 +229,11 @@ impl ProxyHttp for LB {
     }
 
     async fn upstream_request_filter(&self, session: &mut Session, upstream_request: &mut RequestHeader, ctx: &mut Self::CTX) -> Result<()> {
-        if let Some(client_ip) = session.client_addr() {
+        if let Some(ip) = session.client_addr().and_then(|a| a.as_inet()).map(|i| i.ip()) {
             IP_BUFFER.with(|buffer| {
                 let mut buf = buffer.borrow_mut();
                 buf.clear();
-                write!(buf, "{}", client_ip).unwrap_or(());
+                write!(buf, "{}", ip).unwrap_or(());
                 upstream_request.append_header("X-Forwarded-For", buf.as_str()).unwrap_or(false);
             });
         }


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For