### PR TITLE
fix: Fix global rate limit and 4xx limit fallback in upstream config log

### DIFF
--- a/src/utils/kuberconsul.rs
+++ b/src/utils/kuberconsul.rs
@@ -222,7 +222,7 @@ async fn clone_compare(upstreams: &UpstreamsDashMap, prev_upstreams: &UpstreamsD
         };
         clone_dashmap_into(upstreams, prev_upstreams);
         clone_dashmap_into(upstreams, &tosend.upstreams);
-        print_upstreams(&tosend.upstreams);
+        print_upstreams(&tosend.upstreams, &tosend.extraparams);
         return Some(tosend);
     };
     None

--- a/src/utils/parceyaml.rs
+++ b/src/utils/parceyaml.rs
@@ -233,7 +233,7 @@ async fn populate_file_upstreams(config: &mut Configuration, parsed: &Config) {
             clone_dashmap_into(&r, &config.upstreams);
         }
         info!("Upstream Config:");
-        print_upstreams(&config.upstreams);
+        print_upstreams(&config.upstreams, &config.extraparams);
     }
 }
 pub fn parce_main_config(path: &str) -> AppConfig {

--- a/src/utils/tools.rs
+++ b/src/utils/tools.rs
@@ -1,6 +1,6 @@
 use crate::tls::load;
 use crate::tls::load::CertificateConfig;
-use crate::utils::structs::{InnerMap, InnerMapForJson, UpstreamSnapshotForJson, UpstreamsDashMap, UpstreamsIdMap};
+use crate::utils::structs::{InnerMap, InnerMapForJson, Extraparams, UpstreamSnapshotForJson, UpstreamsDashMap, UpstreamsIdMap};
 use dashmap::DashMap;
 use log::{error, info};
 use notify::{event::ModifyKind, Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::{fs, process, thread, time};
 
-pub fn print_upstreams(upstreams: &UpstreamsDashMap) {
+pub fn print_upstreams(upstreams: &UpstreamsDashMap, extraparams: &Extraparams) {
     let mut out = String::new();
     for host_entry in upstreams.iter() {
         writeln!(out, "Hostname: {}", host_entry.key()).unwrap();
@@ -35,8 +35,8 @@ pub fn print_upstreams(upstreams: &UpstreamsDashMap) {
                     f.is_ssl,
                     f.is_http2,
                     f.to_https,
-                    f.rate_limit.unwrap_or(0),
-                    f.x4xx_limit.unwrap_or(0)
+                    f.rate_limit.unwrap_or(extraparams.rate_limit.unwrap_or(0)),
+                    f.x4xx_limit.unwrap_or(extraparams.x4xx_limit.unwrap_or(0))
                 )
                 .unwrap();
             }


### PR DESCRIPTION
### Problem

The upstream configuration logging was displaying incorrect Rate Limit and 4xx Limit values for paths that don't have explicit rate limit settings defined.
Specifically, paths without explicit limits were showing 0 instead of falling back to the global rate limit values (or domain-level limits).

### Root Cause

The `print_upstreams()` function was using `.unwrap_or(0)` as the default fallback for individual paths.
This resulted in displaying 0 for unset path-level limits instead of using the global/domain-level `extraparams` settings.

_Note: This was a logging display bug only.
The actual runtime behavior was already correct—paths without explicit limits were properly using the global settings.
This change ensures the logs accurately reflect what is actually being enforced._

### Solution

Modified the `print_upstreams()` function to accept `extraparams` as a parameter and use the global rate limit settings as the proper fallback:

* Changed `f.rate_limit.unwrap_or(0)` to `f.rate_limit.unwrap_or(extraparams.rate_limit.unwrap_or(0))`

* Changed `f.x4xx_limit.unwrap_or(0)` to `f.x4xx_limit.unwrap_or(extraparams.x4xx_limit.unwrap_or(0))`

### Example Config & Log Comparison

**YAML Configuration**
``` yaml
rate_limit: 5
x4xx_limit: 5
...
upstreams:
  pone.localhost:
    paths:
      "/":
        rate_limit: 6
        x4xx_limit: 6
        servers:
          - "127.0.0.1:2998"
      "/api":
        servers:
          - "127.0.0.1:8000"
```

❌ Before (Showing 0 for /api)

``` text
2026-05-26 14:46:56 INFO aralez::utils::parceyaml - Applied Global Rate Limit : 5 request per second
2026-05-26 14:46:56 INFO aralez::utils::parceyaml - Applied Rate Limit for pone.localhost : 6 request per second
...
Hostname: pone.localhost
    Path: /api
        IP: 127.0.0.1, Port: 8000, SSL: false, H2: false, To HTTPS: false, Rate Limit: 0, 4xx Limit: 0
    Path: /
        IP: 127.0.0.1, Port: 2998, SSL: false, H2: false, To HTTPS: false, Rate Limit: 6, 4xx Limit: 6
```

After (Correctly falling back to 5 for /api)
```
Hostname: pone.localhost
    Path: /api
        IP: 127.0.0.1, Port: 8000, SSL: false, H2: false, To HTTPS: false, Rate Limit: 5, 4xx Limit: 5
    Path: /
        IP: 127.0.0.1, Port: 2998, SSL: false, H2: false, To HTTPS: false, Rate Limit: 6, 4xx Limit: 6
```

### Changes

* src/utils/tools.rs: Updated print_upstreams() function signature and fallback logic.

* src/utils/kuberconsul.rs: Updated function call to pass extraparams.

* src/utils/parceyaml.rs: Updated function call to pass extraparams.