### PR TITLE
Include request path in rate limit and 4xx limit warning logs

### DIFF
--- a/src/web/gethosts.rs
+++ b/src/web/gethosts.rs
@@ -12,17 +12,18 @@ pub struct GetHostsReturHeaders {
 
 #[async_trait]
 pub trait GetHost {
-    fn get_host(&self, peer: &str, path: &str, backend_id: Option<&str>) -> Option<Arc<InnerMap>>;
+    fn get_host(&self, peer: &str, path: &str, backend_id: Option<&str>) -> Option<(Arc<InnerMap>, Arc<str>)>;
 
     fn get_header(&self, peer: &str, path: &str) -> Option<GetHostsReturHeaders>;
     // fn get_upstreams(&self) -> Arc<UpstreamsDashMap>;
 }
 #[async_trait]
 impl GetHost for LB {
-    fn get_host(&self, peer: &str, path: &str, backend_id: Option<&str>) -> Option<Arc<InnerMap>> {
+    fn get_host(&self, peer: &str, path: &str, backend_id: Option<&str>) -> Option<(Arc<InnerMap>, Arc<str>)> {
         if let Some(b) = backend_id {
             if let Some(bb) = self.ump_byid.get(b) {
-                return Some(bb.value().clone());
+                let matched_path: Arc<str> = bb.key().as_str().into();
+                return Some(((bb.value().clone()), matched_path));
             }
         }
         let host_entry = self.ump_upst.get(peer)?;
@@ -33,7 +34,8 @@ impl GetHost for LB {
                 let (servers, index) = entry.value();
                 if !servers.is_empty() {
                     let idx = index.fetch_add(1, Ordering::Relaxed) % servers.len();
-                    return Some(servers[idx].clone());
+                    let matched_path = Arc::clone(entry.key());
+                    return Some(((servers[idx].clone()), matched_path));
                 }
             }
             if let Some(pos) = slice.rfind('/') {
@@ -46,7 +48,8 @@ impl GetHost for LB {
             let (servers, index) = entry.value();
             if !servers.is_empty() {
                 let idx = index.fetch_add(1, Ordering::Relaxed) % servers.len();
-                return Some(servers[idx].clone());
+                let matched_path = Arc::clone(entry.key());
+                return Some(((servers[idx].clone()), matched_path));
             }
         }
         None

--- a/src/web/proxyhttp.rs
+++ b/src/web/proxyhttp.rs
@@ -86,7 +86,7 @@ impl ProxyHttp for LB {
                 let optioninnermap = self.get_host(host, session.req_header().uri.path(), backend_id);
                 match optioninnermap {
                     None => return Ok(false),
-                    Some(ref innermap) => {
+                    Some((ref innermap, ref path)) => {
                         if let Some(auth) = _ctx.extraparams.authentication.as_ref().or(innermap.authorization.as_ref()) {
                             if !authenticate(&auth, session).await {
                                 let _ = session.respond_error(401).await;
@@ -104,7 +104,7 @@ impl ProxyHttp for LB {
                                     session.set_keepalive(None);
                                     session.write_response_header(Box::new(header), true).await?;
                                     if let (Some(oi), Some(oa)) = (&_ctx.hostname, rate_key) {
-                                        warn!("Limit 4XX: {}-rps exceed on {} from {}", rate, oi, oa);
+                                        warn!("Limit 4XX: {}-rps exceed on {} [path: {}] from {}", rate, oi, path, oa);
                                     }
                                     return Ok(true);
                                 }
@@ -118,7 +118,7 @@ impl ProxyHttp for LB {
                                 session.set_keepalive(None);
                                 session.write_response_header(Box::new(header), true).await?;
                                 if let (Some(oi), Some(oa)) = (&_ctx.hostname, rate_key) {
-                                    warn!("Limit: {}-rps exceed on {} from {}", rate, oi, oa);
+                                    warn!("Limit: {}-rps exceed on {} [path: {}] from {}", rate, oi, path, oa);
                                 }
                                 return Ok(true);
                             }
@@ -163,7 +163,7 @@ impl ProxyHttp for LB {
                         }
                     }
                 }
-                _ctx.upstream_peer = optioninnermap;
+                _ctx.upstream_peer = Some(optioninnermap.unwrap().0);
             }
         }
         Ok(false)


### PR DESCRIPTION
### Summary

This pull request improves rate limit and 4xx limit warning messages by including the matched path information, making it easier to diagnose which path rule triggered the rate limit and 4xx limit.

### Problem
Previously, when rate limits were exceeded, the warning messages only showed the hostname and client IP, making it difficult to identify which specific path configuration triggered the limit when multiple paths with different rate limit settings were defined.

**Configuration example:**

```YAML
upstreams:
  pone.localhost:
    paths:
      "/":
        rate_limit: 6
        servers:
          - "127.0.0.1:2998"
      "/api":
        servers:
          - "127.0.0.1:8000"
```

### Solution
Modified the rate limit logging to include the matched path.

**Before:**

```
2026-05-27 15:38:02 WARN aralez::web::proxyhttp - Limit: 6-rps exceed on pone.localhost from 127.0.0.1
2026-05-27 15:39:28 WARN aralez::web::proxyhttp - Limit: 5-rps exceed on pone.localhost from 127.0.0.1
```

**After:**

```
2026-05-27 15:53:34 WARN aralez::web::proxyhttp - Limit: 6-rps exceed on pone.localhost [path: /] from 127.0.0.1
2026-05-27 15:53:40 WARN aralez::web::proxyhttp - Limit: 5-rps exceed on pone.localhost [path: /api] from 127.0.0.1
```

### Note on Log Format Style
If you prefer a different logging style or format instead of `[path: /]` (for example, `/api on pone.localhost` or `pone.localhost/api`), please feel free to modify or rewrite the string formatting to match your preferred style!
I am completely open to any changes on the format.

### Changes
* Updated GetHost trait to return both the inner map and the matched path
* Modified `get_host()` implementation in `LB` to return tuples containing the path information
* Updated warning messages in `proxyhttp.rs` to include the matched path in log output
