### PR TITLE
Skip TLS detection when healthcheck: false

### DIFF
--- a/src/utils/healthcheck.rs
+++ b/src/utils/healthcheck.rs
@@ -53,14 +53,13 @@ async fn build_upstreams(fullist: &UpstreamsDashMap, method: &str, client: &Clie
             let mut innervec = Vec::new();
 
             for upstream in path_entry.value().0.iter() {
-                let tls = detect_tls(upstream.address.as_ref(), &upstream.port, client).await;
-                let is_h2 = matches!(tls.1, Some(Version::HTTP_2));
-
-                let link = if tls.0 {
-                    format!("https://{}:{}{}", upstream.address, upstream.port, path)
+                let tls = if upstream.healthcheck.unwrap_or(true) {
+                    detect_tls(upstream.address.as_ref(), &upstream.port, client).await
                 } else {
-                    format!("http://{}:{}{}", upstream.address, upstream.port, path)
+                    (false, None)
                 };
+
+                let is_h2 = matches!(tls.1, Some(Version::HTTP_2));
 
                 let mut scheme = InnerMap {
                     address: upstream.address.clone(),
@@ -76,6 +75,12 @@ async fn build_upstreams(fullist: &UpstreamsDashMap, method: &str, client: &Clie
                 };
 
                 if scheme.healthcheck.unwrap_or(true) {
+                    let link = if tls.0 {
+                        format!("https://{}:{}{}", upstream.address, upstream.port, path)
+                    } else {
+                        format!("http://{}:{}{}", upstream.address, upstream.port, path)
+                    };
+
                     let resp = http_request(&link, method, "", client).await;
                     if resp.0 {
                         if resp.1 {


### PR DESCRIPTION
### Summary

This fix prevents unnecessary TLS detection and HTTP requests when health checks are disabled for an upstream. Currently, the code always calls `detect_tls()` regardless of the health check configuration, which causes redundant GET requests even when health checks are not needed.

### Changes

- Move `detect_tls()` call inside a conditional check for `upstream.healthcheck`
- Only execute TLS detection when health checks are enabled (default: `true`)
- When health checks are disabled, default to `(false, None)` to avoid unnecessary I/O operations

### Benefits

- Reduces unnecessary network requests when health checks are disabled
- Improves performance for upstreams with health checks disabled

### Testing

Please verify that:
- Upstreams with `healthcheck: false` do not trigger TLS detection or HTTP requests
- Upstreams with `healthcheck: true` (or default) continue to work as before
- HTTP/2 detection still works correctly for enabled health checks

### Additional Optimization Proposal

Looking at the configuration in `etc/upstreams.yaml`, there's a `to_https` flag 
that explicitly controls whether upstreams should use HTTPS. This suggests a 
further optimization opportunity: instead of unconditionally calling `detect_tls()` 
to probe for HTTPS support first and then falling back to HTTP, we could respect 
the `to_https` configuration when it's explicitly set to `false`.

When `to_https: false` is configured, we could skip the HTTPS probe entirely and 
go straight to HTTP health checks. This would eliminate the unnecessary HTTPS 
attempt on every health check cycle and further improve performance for 
HTTP-only upstreams.

### Changes

`src/utils/healthcheck.rs`: Conditionalized the execution of detect_tls based on the healthcheck setting.