### PR TITLE
Fix config file change detection logic in file watcher

### DIFF
--- a/src/utils/filewatch.rs
+++ b/src/utils/filewatch.rs
@@ -37,7 +37,7 @@ pub async fn start(fp: String, mut toreturn: Sender<Configuration>) {
         match event {
             Ok(e) => match e.kind {
                 EventKind::Modify(ModifyKind::Data(_)) | EventKind::Create(..) | EventKind::Remove(..) => {
-                    if e.paths[0].to_str().unwrap().ends_with("yaml") && start.elapsed() > Duration::from_secs(2) {
+                    if e.paths.iter().any(|path| path.to_str() == Some(file_path)) && start.elapsed() > Duration::from_secs(2) {
                         start = Instant::now();
                         // info!("Config File changed :=> {:?}", e);
                         let snd = load_configuration(file_path, "filepath").await.0;


### PR DESCRIPTION
### Description
This PR fixes an issue with the file watcher logic where configuration file changes were not being correctly identified. It changes the path validation mechanism to precisely match the target configuration file path.

### The Problem
Previously, the code in `src/utils/filewatch.rs` used `e.paths[0].to_str().unwrap().ends_with("yaml")` to filter event paths. This approach introduces a few critical bugs:
1. **Hardcoded extension:** The configuration file extension isn't restricted to `.yaml` (e.g., users can specify paths like `/opt/Rust/Projects/asyncweb/etc/upstreams.yml` in `main.yaml`). If a `.yml` file is updated, `load_configuration` is never triggered.
2. **False positives:** Any file ending with `yaml` (like `foo.yaml`) in the watched directory would trigger a reload, even if it wasn't the actual target config file.
3. **Out-of-bounds risk:** It assumes `e.paths` always has at least one element (`e.paths[0]`), which isn't guaranteed.

### Solution
Replaced the strict suffix check on the first element with an iterative check that ensures the exact target file path is contained within the event paths:
```rust
e.paths.iter().any(|path| path.to_str() == Some(file_path))
```
### Future Scope / Note for Reviewers
(Note: This is not included in this PR, but noted for Windows support capability)

To make it easier to add cross-platform support (specifically Windows) in the future, we could eventually refactor the event kind matching.

Changing this:
```rust
Ok(e) => match e.kind {
    EventKind::Modify(ModifyKind::Data(_)) | EventKind::Create(..) | EventKind::Remove(..) => {
```
To this:
```rust
Ok(e) => {
    if matches!(e.kind, EventKind::Modify(ModifyKind::Data(_)) | EventKind::Create(..) | EventKind::Remove(..)) {
```
Would allow us to cleanly abstract the event filtering logic for Unix and Windows down the road, like so:
```rust
fn is_watched_event(kind: &EventKind) -> bool {
    #[cfg(unix)]
    return matches!(kind, EventKind::Modify(ModifyKind::Data(_)) | EventKind::Create(..) | EventKind::Remove(..));
    #[cfg(windows)]
    return matches!(kind, EventKind::Modify(_) | EventKind::Create(..) | EventKind::Remove(..));
}
```
_On Windows, file watcher must check with Modify(Name(To)) or Modify(Any))._