### PR TITLE
Fix TcpListener binding and port availability check

### DIFF
--- a/src/web/webserver.rs
+++ b/src/web/webserver.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 use signal_hook::{consts::SIGQUIT, iterator::Signals};
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
@@ -227,7 +228,8 @@ async fn status(State(st): State<AppState>, Query(params): Query<HashMap<String,
 }
 
 pub async fn port_is_available(name: &str, address: &str) -> TcpListener {
-    let addr: SocketAddr = address.parse().expect("Invalid address format");
+    let addr = SocketAddr::from_str(address)
+        .unwrap_or_else(|e| panic!("{}: Invalid address format: {:?}", name, e));
     let t = Duration::from_secs(2);
 
     //if addr.ip() == IpAddr::V4(Ipv4Addr::UNSPECIFIED) {

--- a/src/web/webserver.rs
+++ b/src/web/webserver.rs
@@ -18,6 +18,7 @@ use prometheus::{gather, Encoder, TextEncoder};
 use serde::Serialize;
 use signal_hook::{consts::SIGQUIT, iterator::Signals};
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::net::TcpListener;
@@ -67,16 +68,14 @@ pub async fn run_server(config: &APIUpstreamProvider, mut to_return: Sender<Conf
 
     let mut static_handle: Option<tokio::task::JoinHandle<()>> = None;
     if let (Some(address), Some(folder)) = (&config.file_server_address, &config.file_server_folder) {
-        port_is_available("File Server", &address).await;
+        let static_listen = port_is_available("File Server", &address).await;
         let static_files = ServeDir::new(folder);
         let static_serve: Router = Router::new().fallback_service(static_files);
-        let static_listen = TcpListener::bind(address).await.unwrap();
         // drop(tokio::spawn(async move { axum::serve(static_listen, static_serve).await.unwrap() }));
         static_handle = Some(tokio::spawn(async move { axum::serve(static_listen, static_serve).await.unwrap() }))
     }
 
-    port_is_available("Config API", &config.address).await;
-    let listener = TcpListener::bind(config.address.clone()).await.unwrap();
+    let listener = port_is_available("Config API", &config.address).await;
     info!("Starting the API server on: {}", config.address);
     let api_server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
@@ -227,20 +226,18 @@ async fn status(State(st): State<AppState>, Query(params): Query<HashMap<String,
         .unwrap()
 }
 
-pub async fn port_is_available(name: &str, address: &str) {
-    let addr_port = address.split(":").collect::<Vec<&str>>();
+pub async fn port_is_available(name: &str, address: &str) -> TcpListener {
+    let addr: SocketAddr = address.parse().expect("Invalid address format");
     let t = Duration::from_secs(2);
 
-    let mut a = addr_port[0];
-    if address == "0.0.0.0" {
-        a = "127.0.0.1";
-    }
-    let p = addr_port[1].parse::<u16>().unwrap();
-
+    //if addr.ip() == IpAddr::V4(Ipv4Addr::UNSPECIFIED) {
+    //    addr.set_ip(IpAddr::V4(Ipv4Addr::LOCALHOST));
+    //}
+    let p = addr.port();
     loop {
-        match TcpListener::bind((a, p)).await {
-            Ok(_) => {
-                break;
+        match TcpListener::bind(addr).await {
+            Ok(listener) => {
+                return listener;
             }
             Err(_) => {
                 warn!("{} port is not available: {} will try again in {:?}", name, p, t);


### PR DESCRIPTION
## Summary
Refactor `port_is_available()` to properly handle address parsing and socket binding, eliminating critical bugs and race conditions.

## Changes
- **Return TcpListener directly**: `port_is_available()` now returns an owned `TcpListener` instead of just checking availability, reducing the bind-and-bind pattern that created a race condition window
- **Use proper address parsing**: Replace string splitting logic with `SocketAddr::from_str()`, which correctly parses `IP:port` format and panics on invalid input rather than silently failing
- **Refactor call sites**: Update `run_server()` to use the returned listener directly, eliminating duplicate `TcpListener::bind()` calls

## Issues Fixed

### 1. **Panic on malformed address strings**
- **Previous behavior**: `address.split(":").collect::<Vec<&str>>()` would panic if the address didn't contain a colon, or silently use wrong indices
- **New behavior**: `SocketAddr::from_str(address)` provides explicit error handling with `.unwrap_or_else(|e| panic!("{}: Invalid address format: {:?}", name, e))`
- **Example**: Passing `"localhost"` (no port) now fails fast with a clear error message instead of panicking unpredictably

### 2. **Race condition between port check and bind**
- **Previous behavior**: 
  ```rust
  port_is_available("Config API", &config.address).await;  // Bind and release
  let listener = TcpListener::bind(config.address).await?;  // Bind again

Another process could grab the port between these two calls

- **New behavior**: The listener is returned and held immediately, eliminating the gap.
 
## Design Questions for Review
### Unspecified Address Handling
The code contains commented-out logic to replace 0.0.0.0 (UNSPECIFIED) with 127.0.0.1 (LOCALHOST):

```rust
//if addr.ip() == IpAddr::V4(Ipv4Addr::UNSPECIFIED) {
//    addr.set_ip(IpAddr::V4(Ipv4Addr::LOCALHOST));
//}
```

Should this be enabled?
- **Current behavior:**
If config specifies 0.0.0.0:8080, the conversion logic is never actually reached because the branching condition is incorrect, but the server still attempts to bind to 127.0.0.1.
No warning or log message indicates this transformation.
This could surprise operators who expect the configured address to match actual binding.

- **Recommended decision:**

1. Enable the replacement and add an info!() log: "Unspecified address 0.0.0.0 replaced with 127.0.0.1 for port availability check"
1. Leave disabled if multi-interface binding is intentional (current state)
1. Add explicit validation in config parsing to reject unspecified addresses and require explicit localhost/IP

## In addition
- **Poor error handling in check_priv() function**
The existing `check_priv()` function in `src/utils/tools.rs` (lines 276-285) has similar error handling issues:
```rust
let port = SocketAddr::from_str(addr).map(|sa| sa.port()).unwrap();
```
`.unwrap()` on `SocketAddr::from_str()` panics without context if the address format is invalid.

- **Suggested improvement
```rust
let port = SocketAddr::from_str(addr).map(|sa| sa.port())
        .unwrap_or_else(|e| panic!("Invalid proxy address format: {:?}", e));
```