### PR TITLE
Fix: Resolve 404/405 errors with sticky session cookie handling in /api routes

### DIFF
--- a/src/utils/tools.rs
+++ b/src/utils/tools.rs
@@ -147,11 +147,8 @@ pub fn clone_idmap_into(original: &UpstreamsDashMap, cloned: &UpstreamsIdMap) {
     cloned.clear();
     for outer_entry in original.iter() {
         let inner_map = outer_entry.value();
-        let new_inner_map = DashMap::new();
         for inner_entry in inner_map.iter() {
-            let path = inner_entry.key();
             let (vec, _) = inner_entry.value();
-            let new_vec = vec.clone();
             for x in vec.iter() {
                 let mut id = String::new();
                 write!(
@@ -175,22 +172,8 @@ pub fn clone_idmap_into(original: &UpstreamsDashMap, cloned: &UpstreamsIdMap) {
                 let hash = hasher.finalize();
                 let hex_hash = base16ct::lower::encode_string(&hash);
                 let hh = hex_hash[0..50].to_string();
-                let to_add = InnerMap {
-                    address: Arc::from("127.0.0.1"),
-                    port: 0,
-                    is_ssl: false,
-                    is_http2: false,
-                    to_https: false,
-                    rate_limit: None,
-                    x4xx_limit: None,
-                    healthcheck: None,
-                    redirect_to: None,
-                    authorization: None,
-                };
-                cloned.insert(id, Arc::from(to_add));
                 cloned.insert(hh, x.to_owned());
             }
-            new_inner_map.insert(path.clone(), new_vec);
         }
     }
     info!("Upstreams are fully populated. Ready to server requests");

--- a/src/web/gethosts.rs
+++ b/src/web/gethosts.rs
@@ -20,21 +20,22 @@ pub trait GetHost {
 #[async_trait]
 impl GetHost for LB {
     fn get_host(&self, peer: &str, path: &str, backend_id: Option<&str>) -> Option<Arc<InnerMap>> {
-        if let Some(b) = backend_id {
-            if let Some(bb) = self.ump_byid.get(b) {
-                return Some(bb.value().clone());
-            }
-        }
         let host_entry = self.ump_upst.get(peer)?;
         let mut end = path.len();
         loop {
             let slice = &path[..end];
             if let Some(entry) = host_entry.get(slice) {
                 let (servers, index) = entry.value();
-                if !servers.is_empty() {
-                    let idx = index.fetch_add(1, Ordering::Relaxed) % servers.len();
-                    return Some(servers[idx].clone());
+                if let Some(b) = backend_id {
+                    if let Some(bb) = self.ump_byid.get(b) {
+                        let target = bb.value();
+                        if servers.iter().any(|s| s.address == target.address && s.port == target.port) {
+                            return Some(target.clone());
+                        }
+                    }
                 }
+                let idx = index.fetch_add(1, Ordering::Relaxed) % servers.len();
+                return Some(servers[idx].clone());
             }
             if let Some(pos) = slice.rfind('/') {
                 end = pos;
@@ -45,10 +46,20 @@ impl GetHost for LB {
         if let Some(entry) = host_entry.get("/") {
             let (servers, index) = entry.value();
             if !servers.is_empty() {
-                let idx = index.fetch_add(1, Ordering::Relaxed) % servers.len();
-                return Some(servers[idx].clone());
+
+                if let Some(b) = backend_id {
+                    if let Some(bb) = self.ump_byid.get(b) {
+                        let target = bb.value();
+                        if servers.iter().any(|s| s.address == target.address && s.port == target.port) {
+                            return Some(target.clone());
+                            }
+                        }
+                    }
+
+                    let idx = index.fetch_add(1, Ordering::Relaxed) % servers.len();
+                    return Some(servers[idx].clone());
+                }
             }
-        }
         None
     }
 


### PR DESCRIPTION
### Problem
When using the following upstream configuration:
```yaml
upstreams:
    127.0.0.1:
        paths:
            "/":
                healthcheck: false
                servers:
                    - "127.0.0.1:2998"
            "/api":
                healthcheck: false
                servers:
                    - "127.0.0.1:2999"
```

The `/api` route was returning 404/405 errors. The issue was traced to the sticky session cookie handling logic interacting incorrectly with the order of upstream reference lookups.

### Root Cause
The problem was introduced in commit `5815da65764fb177c9cccae255f2596295d1e153` (Fixed sadoyan#40) where `clone_idmap_into` was called from `bgservice.rs::start()`. The sticky session cookie logic was checking the cached upstream ID before properly validating that the target server existed in the current path's server list, causing requests to be routed incorrectly.

### Solution

**`src/web/gethosts.rs`** - Reordered host lookup logic:
- Changed the priority: now first resolves the path-based upstream servers, then validates if a sticky session backend_id matches one of those servers
- Only returns the sticky session backend if it's actually available in the current path's server pool
- Falls back to round-robin load balancing if no valid sticky session match is found

**`src/utils/tools.rs`** - Removed dead code:
- Deleted unused variable assignments (`new_inner_map`, `new_vec`, `path`)
- Removed the incorrect dummy `InnerMap` object that was being inserted with placeholder values

### Testing Notes
The recent addition of `access_log` feature has been invaluable for debugging—immediate 404 responses were easily identifiable in the logs, making this analysis much faster. Thank you!